### PR TITLE
Update to latest zig for endian changes

### DIFF
--- a/src/util.zig
+++ b/src/util.zig
@@ -12,6 +12,7 @@ const Stream = std.net.Stream;
 const assert = std.debug.assert;
 
 pub const Bytes = std.ArrayList(u8);
+pub const native_endian = std.builtin.target.cpu.arch.endian();
 
 
 pub fn isCtrlChar(ch: u8) callconv(.Inline) bool {
@@ -264,7 +265,7 @@ pub const IOStream = struct {
             try self.fillBuffer();
         }
         const d = @bitCast(I, self.readBuffered()[0..n].*);
-        const r = if (std.builtin.endian != endian) @byteSwap(I, d) else d;
+        const r = if (endian != native_endian) @byteSwap(I, d) else d;
         self.skipBytes(n);
         return @bitCast(T, r);
     }

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -5,7 +5,9 @@
 // -------------------------------------------------------------------------- //
 const std = @import("std");
 const web = @import("zhp.zig");
+const util = @import("util.zig");
 const log = std.log;
+const native_endian = util.native_endian;
 
 pub const Opcode = enum(u4) {
     Continue = 0x0,
@@ -118,7 +120,7 @@ pub const Websocket = struct {
 
     // Close and send the status
     pub fn close(self: Websocket, code: u16) !void {
-        const c = if (std.builtin.endian == .Big) code else @byteSwap(u16, code);
+        const c = if (native_endian == .Big) code else @byteSwap(u16, code);
         const data = @bitCast([2]u8, c);
         _ = try self.writeMessage(.Close, &data);
     }


### PR DESCRIPTION
The `std.builtin.endian` is gone. Use `std.builtin.target.cpu.arch.endian()` instead.