### PR TITLE
Add explicit `u8` to mem.tokenize

### DIFF
--- a/src/mimetypes.zig
+++ b/src/mimetypes.zig
@@ -310,7 +310,7 @@ pub const Registry = struct {
             // Empty or no spaces
             if (line.len == 0 or mem.indexOf(u8, line, " ") == null) continue;
 
-            var it = mem.tokenize(line, " ");
+            var it = mem.tokenize(u8, line, " ");
             const mime_type = it.next() orelse continue;
             while (it.next()) |ext| {
                 try self.addType(ext, mime_type);


### PR DESCRIPTION
`mem.tokenize` is now generic as of https://github.com/ziglang/zig/pull/9531/commits/05fd20dc104b3654ce9c5d7a22a2bff66a940dba

Edit: I somehow missed some other instances along with mem.split, will open new PR tomorrow/next week