### PR TITLE
Fix compilation errors in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ pub const log_level = .info;
 
 const MainHandler = struct {
     pub fn get(self: *MainHandler, request: *web.Request, response: *web.Response) !void {
+        _ = self;
+        _ = request;
         try response.headers.put("Content-Type", "text/plain");
-        try response.stream.write("Hello, World!");
+        _ = try response.stream.write("Hello, World!");
     }
 
 };
@@ -60,13 +62,13 @@ pub const routes = [_]web.Route{
 };
 
 pub const middleware = [_]web.Middleware{
-    web.Middleware.create(web.middleware.LoggingMiddleware);
+    web.Middleware.create(web.middleware.LoggingMiddleware),
 };
 
 pub fn main() anyerror!void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer std.debug.assert(!gpa.deinit());
-    const allocator = &gpa.allocator;
+    const allocator = gpa.allocator();
 
     var app = web.Application.init(allocator, .{.debug=true});
     defer app.deinit();


### PR DESCRIPTION
This pr fixes #24, i also found some other compilation errors (unused function parameter, expression value is ignored, and Allocgate).